### PR TITLE
Bump `illuminate/events` from `v12.26.3` to `v12.26.4`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.26.3",
         "illuminate/database": "~12.26.3",
-        "illuminate/events": "~12.26.3",
+        "illuminate/events": "~12.26.4",
         "illuminate/filesystem": "~12.26.4",
         "illuminate/http": "~12.26.3",
         "phpoffice/phpspreadsheet": "~5.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97889f50000ca038a0aacf46a4d96a0c",
+    "content-hash": "bfb34cd52669dba603e57090e026ba78",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.26.3",
+            "version": "v12.26.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Bumps `illuminate/events` from `v12.26.3` to `v12.26.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`