### PR TITLE
Bump `illuminate/container` from `v12.26.3` to `v12.26.4`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ghostwriter/event-dispatcher": "~5.0.3",
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
-        "illuminate/container": "~12.26.3",
+        "illuminate/container": "~12.26.4",
         "illuminate/database": "~12.26.4",
         "illuminate/events": "~12.26.4",
         "illuminate/filesystem": "~12.26.4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e96c57cf4ae7e9770bfeb3e8accade7",
+    "content-hash": "cd78b22517c3860dba0774b66e3d8233",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,23 +1127,23 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.26.3",
+            "version": "v12.26.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",
-                "reference": "e1b1266e79e38998879123476618b9a8dce43629"
+                "reference": "c096f6fd0fc1879bb78fb88379e2955e2f8911f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/container/zipball/e1b1266e79e38998879123476618b9a8dce43629",
-                "reference": "e1b1266e79e38998879123476618b9a8dce43629",
+                "url": "https://api.github.com/repos/illuminate/container/zipball/c096f6fd0fc1879bb78fb88379e2955e2f8911f8",
+                "reference": "c096f6fd0fc1879bb78fb88379e2955e2f8911f8",
                 "shasum": ""
             },
             "require": {
                 "illuminate/contracts": "^12.0",
                 "php": "^8.2",
                 "psr/container": "^1.1.1|^2.0.1",
-                "symfony/polyfill-php84": "^1.31",
+                "symfony/polyfill-php84": "^1.33",
                 "symfony/polyfill-php85": "^1.33"
             },
             "provide": {
@@ -1184,7 +1184,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-08-26T15:59:02+00:00"
+            "time": "2025-08-27T18:34:41+00:00"
         },
         {
             "name": "illuminate/contracts",


### PR DESCRIPTION
Bumps `illuminate/container` from `v12.26.3` to `v12.26.4`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`