### PR TITLE
Bump `ghostwriter/coding-standard` to `dev-main#fff26cd`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5259,12 +5259,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86"
+                "reference": "fff26cd848bc705a24156358e4f5efb3b49874a2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/53d9149014e9e11ff0eb23220e21546686bbfc86",
-                "reference": "53d9149014e9e11ff0eb23220e21546686bbfc86",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/fff26cd848bc705a24156358e4f5efb3b49874a2",
+                "reference": "fff26cd848bc705a24156358e4f5efb3b49874a2",
                 "shasum": ""
             },
             "require": {
@@ -5314,8 +5314,7 @@
                 "mockery/mockery": "~1.6.12",
                 "nikic/php-parser": "~5.6.1",
                 "phpunit/phpunit": "~12.3.7",
-                "symfony/var-dumper": "~7.3.2",
-                "vimeo/psalm": "~6.13.1"
+                "symfony/var-dumper": "~7.3.3"
             },
             "default-branch": true,
             "bin": [
@@ -5421,7 +5420,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-28T09:41:39+00:00"
+            "time": "2025-09-02T14:11:39+00:00"
         },
         {
             "name": "ghostwriter/config",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main#53d9149` to `dev-main#fff26cd`.

This pull request changes the following file(s): 

- Update `composer.lock`