### PR TITLE
Bump `illuminate/filesystem` from `v12.26.4` to `v12.27.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "illuminate/container": "~12.26.4",
         "illuminate/database": "~12.26.4",
         "illuminate/events": "~12.26.4",
-        "illuminate/filesystem": "~12.26.4",
+        "illuminate/filesystem": "~12.27.0",
         "illuminate/http": "~12.26.4",
         "phpoffice/phpspreadsheet": "~5.0.0",
         "symfony/css-selector": "~7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cd78b22517c3860dba0774b66e3d8233",
+    "content-hash": "0ad2db1eed3bd2e86c1453c102f15eb1",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.26.4",
+            "version": "v12.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Bumps `illuminate/filesystem` from `v12.26.4` to `v12.27.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`