### PR TITLE
Bump `illuminate/events` from `v12.26.4` to `v12.27.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.26.4",
         "illuminate/database": "~12.26.4",
-        "illuminate/events": "~12.26.4",
+        "illuminate/events": "~12.27.0",
         "illuminate/filesystem": "~12.27.0",
         "illuminate/http": "~12.26.4",
         "phpoffice/phpspreadsheet": "~5.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ad2db1eed3bd2e86c1453c102f15eb1",
+    "content-hash": "8cd579b5bcba0aa265b93d885aaecd78",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.26.4",
+            "version": "v12.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Bumps `illuminate/events` from `v12.26.4` to `v12.27.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`