### PR TITLE
Bump `illuminate/container` from `v12.26.4` to `v12.27.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ghostwriter/event-dispatcher": "~5.0.3",
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
-        "illuminate/container": "~12.26.4",
+        "illuminate/container": "~12.27.0",
         "illuminate/database": "~12.26.4",
         "illuminate/events": "~12.27.0",
         "illuminate/filesystem": "~12.27.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cd579b5bcba0aa265b93d885aaecd78",
+    "content-hash": "1d55135e05131e77a4b42387b3331898",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.26.4",
+            "version": "v12.27.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Bumps `illuminate/container` from `v12.26.4` to `v12.27.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`