### PR TITLE
Bump `illuminate/events` from `v12.27.0` to `v12.27.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.27.0",
         "illuminate/database": "~12.27.0",
-        "illuminate/events": "~12.27.0",
+        "illuminate/events": "~12.27.1",
         "illuminate/filesystem": "~12.27.1",
         "illuminate/http": "~12.27.0",
         "phpoffice/phpspreadsheet": "~5.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5458fcda572f49ace196a106f5d208b1",
+    "content-hash": "7970df17f99292cb5448037b240d6d36",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.27.0",
+            "version": "v12.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Bumps `illuminate/events` from `v12.27.0` to `v12.27.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`