### PR TITLE
Bump `illuminate/container` from `v12.27.0` to `v12.27.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "ghostwriter/event-dispatcher": "~5.0.3",
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
-        "illuminate/container": "~12.27.0",
+        "illuminate/container": "~12.27.1",
         "illuminate/database": "~12.27.0",
         "illuminate/events": "~12.27.1",
         "illuminate/filesystem": "~12.27.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b2c5031052e5efe98655beabbbdfa067",
+    "content-hash": "b62239485ca68f0e9c346b5eb4674dcb",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.27.0",
+            "version": "v12.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Bumps `illuminate/container` from `v12.27.0` to `v12.27.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`