### PR TITLE
Bump `illuminate/database` from `v12.27.0` to `v12.27.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.27.1",
-        "illuminate/database": "~12.27.0",
+        "illuminate/database": "~12.27.1",
         "illuminate/events": "~12.27.1",
         "illuminate/filesystem": "~12.27.1",
         "illuminate/http": "~12.27.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b62239485ca68f0e9c346b5eb4674dcb",
+    "content-hash": "970fca9a4717f1d2696d737d10d9bad6",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,16 +1236,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.27.0",
+            "version": "v12.27.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "89377117c4d0180bb6215c2490f3e706690bd56c"
+                "reference": "e146a979f7721fc1ff1a28b1bcdbeb7b367bb03d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/89377117c4d0180bb6215c2490f3e706690bd56c",
-                "reference": "89377117c4d0180bb6215c2490f3e706690bd56c",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/e146a979f7721fc1ff1a28b1bcdbeb7b367bb03d",
+                "reference": "e146a979f7721fc1ff1a28b1bcdbeb7b367bb03d",
                 "shasum": ""
             },
             "require": {
@@ -1303,7 +1303,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-02T15:29:48+00:00"
+            "time": "2025-09-02T15:31:06+00:00"
         },
         {
             "name": "illuminate/events",


### PR DESCRIPTION
Bumps `illuminate/database` from `v12.27.0` to `v12.27.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`