### PR TITLE
Bump `symfony/css-selector` from `v2.0.25` to `v7.3.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "illuminate/filesystem": "~12.27.1",
         "illuminate/http": "~12.27.1",
         "phpoffice/phpspreadsheet": "~5.0.0",
-        "symfony/css-selector": "~2.0.25",
+        "symfony/css-selector": "~7.3.0",
         "symfony/dom-crawler": "~2.0.25"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "97d505c7e3f6837226140c3445a2dc7e",
+    "content-hash": "8289aede77cd0ad263b936742e4ce7d4",
     "packages": [
         {
             "name": "brick/math",
@@ -2712,27 +2712,29 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v2.0.25",
-            "target-dir": "Symfony/Component/CssSelector",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "354d622bce93ab079ed0ca16874f5815f2a73323"
+                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/354d622bce93ab079ed0ca16874f5815f2a73323",
-                "reference": "354d622bce93ab079ed0ca16874f5815f2a73323",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/601a5ce9aaad7bf10797e3663faefce9e26c24e2",
+                "reference": "601a5ce9aaad7bf10797e3663faefce9e26c24e2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.2"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
-                "psr-0": {
-                    "Symfony\\Component\\CssSelector": ""
-                }
+                "psr-4": {
+                    "Symfony\\Component\\CssSelector\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2740,20 +2742,38 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "http://symfony.com/contributors"
-                },
-                {
                     "name": "Fabien Potencier",
                     "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Jean-François Simon",
+                    "email": "jeanfrancois.simon@sensiolabs.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
-            "description": "Symfony CssSelector Component",
-            "homepage": "http://symfony.com",
+            "description": "Converts CSS selectors to XPath expressions",
+            "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v2.0.25"
+                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
             },
-            "time": "2013-01-07T11:07:21+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",


### PR DESCRIPTION
Bumps `symfony/css-selector` from `v2.0.25` to `v7.3.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`