### PR TITLE
Bump `illuminate/filesystem` from `v12.27.1` to `v12.28.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "~12.27.1",
         "illuminate/database": "~12.27.1",
         "illuminate/events": "~12.27.1",
-        "illuminate/filesystem": "~12.27.1",
+        "illuminate/filesystem": "~12.28.0",
         "illuminate/http": "~12.27.1",
         "phpoffice/phpspreadsheet": "~5.0.0",
         "symfony/css-selector": "~7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0125b8397c83f3fbe54f97e4903b929",
+    "content-hash": "97d65baf4f685906d67a42c769f6c941",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.27.1",
+            "version": "v12.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Bumps `illuminate/filesystem` from `v12.27.1` to `v12.28.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`