### PR TITLE
Bump `illuminate/container` from `v12.27.1` to `v12.28.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "~5.0.3",
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
-        "illuminate/container": "~12.27.1",
+        "illuminate/container": "~12.28.0",
         "illuminate/database": "~12.27.1",
         "illuminate/events": "~12.28.0",
         "illuminate/filesystem": "~12.28.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1463983e48b9d548604ee8782dd5e473",
+    "content-hash": "3c1163213d21256d355ecffd7b3c042c",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.27.1",
+            "version": "v12.28.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Bumps `illuminate/container` from `v12.27.1` to `v12.28.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`