### PR TITLE
Bump `illuminate/container` from `v12.28.0` to `v12.28.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "~5.0.3",
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
-        "illuminate/container": "~12.28.0",
+        "illuminate/container": "~12.28.1",
         "illuminate/database": "~12.28.0",
         "illuminate/events": "~12.28.0",
         "illuminate/filesystem": "~12.28.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7d04944b47a7913a0115f73005cd838c",
+    "content-hash": "669237354a4e083f3cb6c749bfbf9694",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.28.0",
+            "version": "v12.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Bumps `illuminate/container` from `v12.28.0` to `v12.28.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`