### PR TITLE
Bump `illuminate/http` from `v12.28.0` to `v12.28.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "~12.28.0",
         "illuminate/events": "~12.28.0",
         "illuminate/filesystem": "~12.28.0",
-        "illuminate/http": "~12.28.0",
+        "illuminate/http": "~12.28.1",
         "phpoffice/phpspreadsheet": "~5.1.0",
         "symfony/css-selector": "~7.3.0",
         "symfony/dom-crawler": "~7.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "669237354a4e083f3cb6c749bfbf9694",
+    "content-hash": "438c2d860c52c8b5f62eef854230bda4",
     "packages": [
         {
             "name": "brick/math",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v12.28.0",
+            "version": "v12.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",


### PR DESCRIPTION
Bumps `illuminate/http` from `v12.28.0` to `v12.28.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`