### PR TITLE
Bump `illuminate/database` from `v12.28.0` to `v12.28.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "~1.0.3",
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.28.1",
-        "illuminate/database": "~12.28.0",
+        "illuminate/database": "~12.28.1",
         "illuminate/events": "~12.28.0",
         "illuminate/filesystem": "~12.28.0",
         "illuminate/http": "~12.28.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "438c2d860c52c8b5f62eef854230bda4",
+    "content-hash": "831ef07a4b39d183d93e34bfafdad9d0",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,7 +1236,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.28.0",
+            "version": "v12.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Bumps `illuminate/database` from `v12.28.0` to `v12.28.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`