### PR TITLE
Bump `illuminate/events` from `v12.28.0` to `v12.28.1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.28.1",
         "illuminate/database": "~12.28.1",
-        "illuminate/events": "~12.28.0",
+        "illuminate/events": "~12.28.1",
         "illuminate/filesystem": "~12.28.1",
         "illuminate/http": "~12.28.1",
         "phpoffice/phpspreadsheet": "~5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "77530b5f59529dfce836e7bad40a35b9",
+    "content-hash": "3c070fd60289cfc033d4c1a379dae12d",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.28.0",
+            "version": "v12.28.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Bumps `illuminate/events` from `v12.28.0` to `v12.28.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`