### PR TITLE
Bump `illuminate/events` from `v12.28.1` to `v12.29.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "~7.10.0",
         "illuminate/container": "~12.28.1",
         "illuminate/database": "~12.28.1",
-        "illuminate/events": "~12.28.1",
+        "illuminate/events": "~12.29.0",
         "illuminate/filesystem": "~12.29.0",
         "illuminate/http": "~12.28.1",
         "phpoffice/phpspreadsheet": "~5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b68f4e23c4182d2049b2432a6fddd132",
+    "content-hash": "e9dbe2ad4428810281112ac504fc99f1",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,16 +1307,16 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.28.1",
+            "version": "v12.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
-                "reference": "2017f20e234e1be566c739fc9d4518e33a34ecc3"
+                "reference": "9b6d9f2176982a9bba5320c6a3481f1f802aec96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/events/zipball/2017f20e234e1be566c739fc9d4518e33a34ecc3",
-                "reference": "2017f20e234e1be566c739fc9d4518e33a34ecc3",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/9b6d9f2176982a9bba5320c6a3481f1f802aec96",
+                "reference": "9b6d9f2176982a9bba5320c6a3481f1f802aec96",
                 "shasum": ""
             },
             "require": {
@@ -1358,7 +1358,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-08-20T13:36:50+00:00"
+            "time": "2025-09-12T14:43:55+00:00"
         },
         {
             "name": "illuminate/filesystem",


### PR DESCRIPTION
Bumps `illuminate/events` from `v12.28.1` to `v12.29.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`