### PR TITLE
Update illuminate/http to version 12.31.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "^12.30.1",
         "illuminate/events": "^12.30.1",
         "illuminate/filesystem": "^12.31.0",
-        "illuminate/http": "^12.30.1",
+        "illuminate/http": "^12.31.0",
         "phpoffice/phpspreadsheet": "^5.1.0",
         "symfony/css-selector": "^7.3.0",
         "symfony/dom-crawler": "^7.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4f75d2f9ac11858438b251722bd38a2e",
+    "content-hash": "5b79b9d07c21653f55d3b30dbff88b92",
     "packages": [
         {
             "name": "brick/math",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v12.30.1",
+            "version": "v12.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",


### PR DESCRIPTION
Updates the `illuminate/http` dependency from `v12.30.1` to `12.31.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`