### PR TITLE
Update illuminate/container to version 12.31.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.30.1",
+        "illuminate/container": "^12.31.0",
         "illuminate/database": "^12.30.1",
         "illuminate/events": "^12.30.1",
         "illuminate/filesystem": "^12.31.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b79b9d07c21653f55d3b30dbff88b92",
+    "content-hash": "f6b24c175bf74107f9cff8914b257abc",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.30.1",
+            "version": "v12.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.30.1` to `12.31.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`