### PR TITLE
Update illuminate/http to version 12.31.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "^12.30.1",
         "illuminate/events": "^12.30.1",
         "illuminate/filesystem": "^12.31.1",
-        "illuminate/http": "^12.31.0",
+        "illuminate/http": "^12.31.1",
         "phpoffice/phpspreadsheet": "^5.1.0",
         "symfony/css-selector": "^7.3.0",
         "symfony/dom-crawler": "^7.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf364de48b5754eef0522c9919d3c57a",
+    "content-hash": "abfed5c38792896bd069c81f0d236fc7",
     "packages": [
         {
             "name": "brick/math",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v12.31.0",
+            "version": "v12.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",


### PR DESCRIPTION
Updates the `illuminate/http` dependency from `v12.31.0` to `12.31.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`