### PR TITLE
Update illuminate/container to version 12.31.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.31.0",
+        "illuminate/container": "^12.31.1",
         "illuminate/database": "^12.30.1",
         "illuminate/events": "^12.30.1",
         "illuminate/filesystem": "^12.31.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "abfed5c38792896bd069c81f0d236fc7",
+    "content-hash": "a8174fe921a00e16242e597dfb9d0495",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.31.0",
+            "version": "v12.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.31.0` to `12.31.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`