### PR TITLE
Update illuminate/events to version 12.31.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.31.1",
         "illuminate/database": "^12.30.1",
-        "illuminate/events": "^12.30.1",
+        "illuminate/events": "^12.31.1",
         "illuminate/filesystem": "^12.31.1",
         "illuminate/http": "^12.31.1",
         "phpoffice/phpspreadsheet": "^5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a8174fe921a00e16242e597dfb9d0495",
+    "content-hash": "2d17e65030f4edfbedc7eb34499b94b4",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.30.1",
+            "version": "v12.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.30.1` to `12.31.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`