### PR TITLE
Update illuminate/database to version 12.31.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.31.1",
-        "illuminate/database": "^12.30.1",
+        "illuminate/database": "^12.31.1",
         "illuminate/events": "^12.31.1",
         "illuminate/filesystem": "^12.31.1",
         "illuminate/http": "^12.31.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d17e65030f4edfbedc7eb34499b94b4",
+    "content-hash": "672c0acbd35eca05f5112dec63e0af84",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,7 +1236,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.30.1",
+            "version": "v12.31.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.30.1` to `12.31.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`