### PR TITLE
Update illuminate/filesystem to version 12.32.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.31.1",
         "illuminate/database": "^12.31.1",
         "illuminate/events": "^12.31.1",
-        "illuminate/filesystem": "^12.31.1",
+        "illuminate/filesystem": "^12.32.0",
         "illuminate/http": "^12.31.1",
         "phpoffice/phpspreadsheet": "^5.1.0",
         "symfony/css-selector": "^7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "672c0acbd35eca05f5112dec63e0af84",
+    "content-hash": "b8332500c761f06f1226deb67090e207",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.31.1",
+            "version": "v12.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "d458bc675ced0b9db3ec4f10aa382b245a4b1cf6"
+                "reference": "b71418cc80e3a150ea037c0946c1b4932bba79b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/d458bc675ced0b9db3ec4f10aa382b245a4b1cf6",
-                "reference": "d458bc675ced0b9db3ec4f10aa382b245a4b1cf6",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/b71418cc80e3a150ea037c0946c1b4932bba79b1",
+                "reference": "b71418cc80e3a150ea037c0946c1b4932bba79b1",
                 "shasum": ""
             },
             "require": {
@@ -1425,7 +1425,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-08-19T13:36:00+00:00"
+            "time": "2025-09-24T18:32:43+00:00"
         },
         {
             "name": "illuminate/http",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.31.1` to `12.32.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`