### PR TITLE
Update illuminate/container to version 12.32.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.31.1",
+        "illuminate/container": "^12.32.1",
         "illuminate/database": "^12.31.1",
         "illuminate/events": "^12.31.1",
         "illuminate/filesystem": "^12.32.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c4ad3381c0bd94636f92550e8f95629",
+    "content-hash": "7aba09f92503411818c1e178a2369ce5",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.31.1",
+            "version": "v12.32.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.31.1` to `12.32.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`