### PR TITLE
Update illuminate/container to version 12.32.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.32.1",
+        "illuminate/container": "^12.32.2",
         "illuminate/database": "^12.31.1",
         "illuminate/events": "^12.32.1",
         "illuminate/filesystem": "^12.32.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2086da53f8f2a84ef6b020abe402870f",
+    "content-hash": "9ac25471d465c06f249ce69d5f72776a",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.32.1",
+            "version": "v12.32.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.32.1` to `12.32.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`