### PR TITLE
Update illuminate/container to version 12.32.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.32.3",
+        "illuminate/container": "^12.32.5",
         "illuminate/database": "^12.32.3",
         "illuminate/events": "^12.32.1",
         "illuminate/filesystem": "^12.32.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "805b6206ac59db1291b763ce94c0d6fa",
+    "content-hash": "ace829b5547d3d80ec6d3391b7bba46a",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.32.3",
+            "version": "v12.32.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.32.3` to `12.32.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`