### PR TITLE
Update illuminate/events to version 12.32.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.32.5",
         "illuminate/database": "^12.32.3",
-        "illuminate/events": "^12.32.1",
+        "illuminate/events": "^12.32.5",
         "illuminate/filesystem": "^12.32.5",
         "illuminate/http": "^12.32.5",
         "phpoffice/phpspreadsheet": "^5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "84a0167c572c0ba3713d97375da27724",
+    "content-hash": "71ed034c12de2b9c8346e5749e22fd71",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.32.1",
+            "version": "v12.32.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.32.1` to `12.32.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`