### PR TITLE
Update illuminate/database to version 12.32.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.32.5",
-        "illuminate/database": "^12.32.3",
+        "illuminate/database": "^12.32.5",
         "illuminate/events": "^12.32.5",
         "illuminate/filesystem": "^12.32.5",
         "illuminate/http": "^12.32.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "71ed034c12de2b9c8346e5749e22fd71",
+    "content-hash": "bd35f90bfa734663ef558f8637d5e3ef",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,7 +1236,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.32.3",
+            "version": "v12.32.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.32.3` to `12.32.5`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`