### PR TITLE
Update illuminate/container to version 12.33.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.32.5",
+        "illuminate/container": "^12.33.0",
         "illuminate/database": "^12.32.5",
         "illuminate/events": "^12.32.5",
         "illuminate/filesystem": "^12.32.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd35f90bfa734663ef558f8637d5e3ef",
+    "content-hash": "78d611771d914c6956a33baef5a36d4c",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.32.5",
+            "version": "v12.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.32.5` to `12.33.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`