### PR TITLE
Update illuminate/events to version 12.33.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.33.0",
         "illuminate/database": "^12.32.5",
-        "illuminate/events": "^12.32.5",
+        "illuminate/events": "^12.33.0",
         "illuminate/filesystem": "^12.32.5",
         "illuminate/http": "^12.32.5",
         "phpoffice/phpspreadsheet": "^5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78d611771d914c6956a33baef5a36d4c",
+    "content-hash": "f29535145956c3f3714239d89b53318e",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.32.5",
+            "version": "v12.33.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.32.5` to `12.33.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`