### PR TITLE
Update illuminate/container to version 12.34.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.33.0",
+        "illuminate/container": "^12.34.0",
         "illuminate/database": "^12.33.0",
         "illuminate/events": "^12.33.0",
         "illuminate/filesystem": "^12.33.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fcd4b45f4e945a5519a70b95b2a1825d",
+    "content-hash": "bf948c59a602048d3b170b880125466a",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.33.0",
+            "version": "v12.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.33.0` to `12.34.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`