### PR TITLE
Update illuminate/events to version 12.34.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.34.0",
         "illuminate/database": "^12.33.0",
-        "illuminate/events": "^12.33.0",
+        "illuminate/events": "^12.34.0",
         "illuminate/filesystem": "^12.33.0",
         "illuminate/http": "^12.33.0",
         "phpoffice/phpspreadsheet": "^5.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf948c59a602048d3b170b880125466a",
+    "content-hash": "9746e52e07a100f0f7edc58f130764a5",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.33.0",
+            "version": "v12.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.33.0` to `12.34.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`