### PR TITLE
Update illuminate/filesystem to version 12.34.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.34.0",
         "illuminate/database": "^12.33.0",
         "illuminate/events": "^12.34.0",
-        "illuminate/filesystem": "^12.33.0",
+        "illuminate/filesystem": "^12.34.0",
         "illuminate/http": "^12.33.0",
         "phpoffice/phpspreadsheet": "^5.1.0",
         "symfony/css-selector": "^7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9746e52e07a100f0f7edc58f130764a5",
+    "content-hash": "5e274110f295a42024b0e944249e8131",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.33.0",
+            "version": "v12.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.33.0` to `12.34.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`