### PR TITLE
Update illuminate/database to version 12.34.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.34.0",
-        "illuminate/database": "^12.33.0",
+        "illuminate/database": "^12.34.0",
         "illuminate/events": "^12.34.0",
         "illuminate/filesystem": "^12.34.0",
         "illuminate/http": "^12.33.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e274110f295a42024b0e944249e8131",
+    "content-hash": "2faa1a01bc50dd39db8cf1320c0767e4",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,16 +1236,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.33.0",
+            "version": "v12.34.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "cce8bca069820c32b51abbd54f732956b872cc6d"
+                "reference": "3ad07bda64019d18fc6fda97fec0b3b7cb6ecae1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/cce8bca069820c32b51abbd54f732956b872cc6d",
-                "reference": "cce8bca069820c32b51abbd54f732956b872cc6d",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/3ad07bda64019d18fc6fda97fec0b3b7cb6ecae1",
+                "reference": "3ad07bda64019d18fc6fda97fec0b3b7cb6ecae1",
                 "shasum": ""
             },
             "require": {
@@ -1303,7 +1303,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-30T19:12:33+00:00"
+            "time": "2025-10-10T13:33:40+00:00"
         },
         {
             "name": "illuminate/events",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.33.0` to `12.34.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`