### PR TITLE
Update illuminate/filesystem to version 12.35.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.35.1",
         "illuminate/database": "^12.34.0",
         "illuminate/events": "^12.35.1",
-        "illuminate/filesystem": "^12.34.0",
+        "illuminate/filesystem": "^12.35.1",
         "illuminate/http": "^12.34.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "368880112bdf2bf51eca8112c316b9aa",
+    "content-hash": "5bbe3cb90bb5f56065f8df72f133d271",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.34.0",
+            "version": "v12.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "c7c3bbcd05c0836af89f1b49bf70c3170c011c13"
+                "reference": "e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/c7c3bbcd05c0836af89f1b49bf70c3170c011c13",
-                "reference": "c7c3bbcd05c0836af89f1b49bf70c3170c011c13",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555",
+                "reference": "e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555",
                 "shasum": ""
             },
             "require": {
@@ -1425,7 +1425,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-09-30T17:35:38+00:00"
+            "time": "2025-10-22T19:48:35+00:00"
         },
         {
             "name": "illuminate/http",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.34.0` to `12.35.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`