### PR TITLE
Update illuminate/events to version 12.36.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.36.0",
         "illuminate/database": "^12.36.0",
-        "illuminate/events": "^12.35.1",
+        "illuminate/events": "^12.36.0",
         "illuminate/filesystem": "^12.35.1",
         "illuminate/http": "^12.35.1",
         "phpoffice/phpspreadsheet": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24fac74ee9889b5f260f4379de3f5345",
+    "content-hash": "ca27615d3ad714c6a4678cdfd291b62e",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.35.1",
+            "version": "v12.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.35.1` to `12.36.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`