### PR TITLE
Update illuminate/filesystem to version 12.36.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.36.0",
         "illuminate/database": "^12.36.0",
         "illuminate/events": "^12.36.0",
-        "illuminate/filesystem": "^12.35.1",
+        "illuminate/filesystem": "^12.36.0",
         "illuminate/http": "^12.36.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0250f0fcafef5fa9155b394c1e808f1c",
+    "content-hash": "af9e3a451aa4124a2909a624fd60a205",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,16 +1362,16 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.35.1",
+            "version": "v12.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",
-                "reference": "e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555"
+                "reference": "46a3cdb0c572c0956d06ac70a819b32199d9717a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555",
-                "reference": "e54ff0a5bcc57cea12bedcc804c6d8eb8a4d3555",
+                "url": "https://api.github.com/repos/illuminate/filesystem/zipball/46a3cdb0c572c0956d06ac70a819b32199d9717a",
+                "reference": "46a3cdb0c572c0956d06ac70a819b32199d9717a",
                 "shasum": ""
             },
             "require": {
@@ -1425,7 +1425,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-10-22T19:48:35+00:00"
+            "time": "2025-10-26T17:15:12+00:00"
         },
         {
             "name": "illuminate/http",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.35.1` to `12.36.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`