### PR TITLE
Update illuminate/events to version 12.36.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.36.1",
         "illuminate/database": "^12.36.0",
-        "illuminate/events": "^12.36.0",
+        "illuminate/events": "^12.36.1",
         "illuminate/filesystem": "^12.36.0",
         "illuminate/http": "^12.36.0",
         "phpoffice/phpspreadsheet": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9910b4a6d02ff3d0379f433e2562d018",
+    "content-hash": "93e68a3e4947a944980e3c43bd93ae93",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.36.0",
+            "version": "v12.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.36.0` to `12.36.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`