### PR TITLE
Update illuminate/filesystem to version 12.36.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.36.1",
         "illuminate/database": "^12.36.0",
         "illuminate/events": "^12.36.1",
-        "illuminate/filesystem": "^12.36.0",
+        "illuminate/filesystem": "^12.36.1",
         "illuminate/http": "^12.36.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "93e68a3e4947a944980e3c43bd93ae93",
+    "content-hash": "de9918a80da0e7cc41218e8add578e9e",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.36.0",
+            "version": "v12.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.36.0` to `12.36.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`