### PR TITLE
Update illuminate/database to version 12.36.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.36.1",
-        "illuminate/database": "^12.36.0",
+        "illuminate/database": "^12.36.1",
         "illuminate/events": "^12.36.1",
         "illuminate/filesystem": "^12.36.1",
         "illuminate/http": "^12.36.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "de9918a80da0e7cc41218e8add578e9e",
+    "content-hash": "13b510d69d6c81dbf1afd89cf4eb3375",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,7 +1236,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.36.0",
+            "version": "v12.36.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.36.0` to `12.36.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`