### PR TITLE
Update ghostwriter/coding-standard to version dev-main#f3c3de9

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5132,19 +5132,18 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "1385d07484e3e069700f770311b6ca1778bcb4b9"
+                "reference": "f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1385d07484e3e069700f770311b6ca1778bcb4b9",
-                "reference": "1385d07484e3e069700f770311b6ca1778bcb4b9",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8",
+                "reference": "f3c3de98f47dbbf5b2fd7f9b4511b6c78ec9a8f8",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "~2.6.0",
                 "composer-runtime-api": "~2.2.2",
                 "composer/composer": "^2.8.12",
-                "composer/semver": "^3.4.4",
                 "ext-ctype": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
@@ -5283,7 +5282,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-02T21:46:52+00:00"
+            "time": "2025-11-02T23:22:26+00:00"
         },
         {
             "name": "ghostwriter/psalm-plugin",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#1385d07` to `dev-main#f3c3de9`.

This pull request changes the following file(s): 

- Update `composer.lock`