### PR TITLE
Update illuminate/http to version 12.37.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "^12.36.1",
         "illuminate/events": "^12.36.1",
         "illuminate/filesystem": "^12.37.0",
-        "illuminate/http": "^12.36.1",
+        "illuminate/http": "^12.37.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.0",
         "symfony/dom-crawler": "^7.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f484659458dd30cbe86f24b51b0dea56",
+    "content-hash": "20577adf9d90b526eb5dac93ee92f18e",
     "packages": [
         {
             "name": "brick/math",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v12.36.1",
+            "version": "v12.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",


### PR DESCRIPTION
Updates the `illuminate/http` dependency from `v12.36.1` to `12.37.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`