### PR TITLE
Update illuminate/events to version 12.37.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.37.0",
         "illuminate/database": "^12.36.1",
-        "illuminate/events": "^12.36.1",
+        "illuminate/events": "^12.37.0",
         "illuminate/filesystem": "^12.37.0",
         "illuminate/http": "^12.37.0",
         "phpoffice/phpspreadsheet": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20577adf9d90b526eb5dac93ee92f18e",
+    "content-hash": "fe622d56357d469102720894c7e90f55",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.36.1",
+            "version": "v12.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.36.1` to `12.37.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`