### PR TITLE
Update illuminate/http to version 12.38.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,7 @@
         "illuminate/database": "^12.37.0",
         "illuminate/events": "^12.37.0",
         "illuminate/filesystem": "^12.37.0",
-        "illuminate/http": "^12.37.0",
+        "illuminate/http": "^12.38.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.6",
         "symfony/dom-crawler": "^7.3.3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8dac81a848df120e21acdf0940637b7",
+    "content-hash": "7924035c80056f8dd3baa8d063449d1a",
     "packages": [
         {
             "name": "brick/math",
@@ -1429,7 +1429,7 @@
         },
         {
             "name": "illuminate/http",
-            "version": "v12.37.0",
+            "version": "v12.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/http.git",


### PR DESCRIPTION
Updates the `illuminate/http` dependency from `v12.37.0` to `12.38.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`