### PR TITLE
Update illuminate/events to version 12.38.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.38.0",
         "illuminate/database": "^12.38.0",
-        "illuminate/events": "^12.37.0",
+        "illuminate/events": "^12.38.0",
         "illuminate/filesystem": "^12.37.0",
         "illuminate/http": "^12.38.0",
         "phpoffice/phpspreadsheet": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fac1338f028d463e0c88f3db61cb1bc8",
+    "content-hash": "1287405e61de0ca6ba3cd3128d966b4c",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.37.0",
+            "version": "v12.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.37.0` to `12.38.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`