### PR TITLE
Update illuminate/filesystem to version 12.38.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.38.0",
         "illuminate/database": "^12.38.0",
         "illuminate/events": "^12.38.0",
-        "illuminate/filesystem": "^12.37.0",
+        "illuminate/filesystem": "^12.38.0",
         "illuminate/http": "^12.38.0",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1287405e61de0ca6ba3cd3128d966b4c",
+    "content-hash": "6af60ed213d05769046910d406353215",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.37.0",
+            "version": "v12.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.37.0` to `12.38.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`