### PR TITLE
Update illuminate/container to version 12.38.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/event-dispatcher": "^5.0.3",
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
-        "illuminate/container": "^12.38.0",
+        "illuminate/container": "^12.38.1",
         "illuminate/database": "^12.38.0",
         "illuminate/events": "^12.38.0",
         "illuminate/filesystem": "^12.38.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6af60ed213d05769046910d406353215",
+    "content-hash": "ad08e9cc1d793dd682919ebef6f9ae10",
     "packages": [
         {
             "name": "brick/math",
@@ -1127,7 +1127,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v12.38.0",
+            "version": "v12.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v12.38.0` to `12.38.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`