### PR TITLE
Update illuminate/database to version 12.38.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "ghostwriter/uuid": "^1.0.3",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.38.1",
-        "illuminate/database": "^12.38.0",
+        "illuminate/database": "^12.38.1",
         "illuminate/events": "^12.38.0",
         "illuminate/filesystem": "^12.38.0",
         "illuminate/http": "^12.38.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4ffd932058c4aaa4e8e1cf2d07a9f7b",
+    "content-hash": "c00e3958a388b93637daea42ecd4213f",
     "packages": [
         {
             "name": "brick/math",
@@ -1236,7 +1236,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.38.0",
+            "version": "v12.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.38.0` to `12.38.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`