### PR TITLE
Update illuminate/filesystem to version 12.38.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/container": "^12.38.1",
         "illuminate/database": "^12.38.1",
         "illuminate/events": "^12.38.1",
-        "illuminate/filesystem": "^12.38.0",
+        "illuminate/filesystem": "^12.38.1",
         "illuminate/http": "^12.38.1",
         "phpoffice/phpspreadsheet": "^5.2.0",
         "symfony/css-selector": "^7.3.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11457d1aded817ac7132f6e3e61561b1",
+    "content-hash": "0248455aa7c3d59f33ace73023488140",
     "packages": [
         {
             "name": "brick/math",
@@ -1362,7 +1362,7 @@
         },
         {
             "name": "illuminate/filesystem",
-            "version": "v12.38.0",
+            "version": "v12.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/filesystem.git",


### PR DESCRIPTION
Updates the `illuminate/filesystem` dependency from `v12.38.0` to `12.38.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`