### PR TITLE
Update illuminate/events to version 12.40.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/container": "^12.40.2",
         "illuminate/database": "^12.38.1",
-        "illuminate/events": "^12.38.1",
+        "illuminate/events": "^12.40.2",
         "illuminate/filesystem": "^12.38.1",
         "illuminate/http": "^12.38.1",
         "phpoffice/phpspreadsheet": "^5.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4ff949080e54c40df3e2891b79289ed7",
+    "content-hash": "be1b1bb5c3814f1ab033b12aab781e10",
     "packages": [
         {
             "name": "brick/math",
@@ -1307,7 +1307,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.38.1",
+            "version": "v12.40.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.38.1` to `12.40.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`