### PR TITLE
Update ghostwriter/coding-standard to version dev-main#ecac8c6

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4238,12 +4238,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852"
+                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/f3eb328a44b318208f7c5e5f65a99d9ff6670852",
-                "reference": "f3eb328a44b318208f7c5e5f65a99d9ff6670852",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ecac8c6c4623c773fd3ff7977d21a950ea31410c",
+                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c",
                 "shasum": ""
             },
             "require": {
@@ -4303,7 +4303,7 @@
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
                 "php": "~8.4.0 || ~8.5.0",
-                "phpunit/phpunit": "^12.4.4",
+                "phpunit/phpunit": "^12.4.5",
                 "symfony/process": "^8.0.0",
                 "symfony/var-dumper": "^8.0.0"
             },
@@ -4419,7 +4419,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-29T21:23:11+00:00"
+            "time": "2025-12-01T08:55:04+00:00"
         },
         {
             "name": "ghostwriter/psalm-plugin",
@@ -5349,16 +5349,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.4.4",
+            "version": "12.4.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7"
+                "reference": "5af317802efd27d5b9cbe048e3760d4a2f687f45"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/9253ec75a672e39fcc9d85bdb61448215b8162c7",
-                "reference": "9253ec75a672e39fcc9d85bdb61448215b8162c7",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/5af317802efd27d5b9cbe048e3760d4a2f687f45",
+                "reference": "5af317802efd27d5b9cbe048e3760d4a2f687f45",
                 "shasum": ""
             },
             "require": {
@@ -5426,7 +5426,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.4"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.4.5"
             },
             "funding": [
                 {
@@ -5450,7 +5450,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-21T07:39:11+00:00"
+            "time": "2025-12-01T07:40:15+00:00"
         },
         {
             "name": "psr/log",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#f3eb328` to `dev-main#ecac8c6`.

This pull request changes the following file(s): 

- Update `composer.lock`