### PR TITLE
Update ghostwriter/coding-standard to version dev-main#13ba985

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4238,12 +4238,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c"
+                "reference": "13ba98577d324beb77c70c05a63d75bfd3c08da9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/ecac8c6c4623c773fd3ff7977d21a950ea31410c",
-                "reference": "ecac8c6c4623c773fd3ff7977d21a950ea31410c",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/13ba98577d324beb77c70c05a63d75bfd3c08da9",
+                "reference": "13ba98577d324beb77c70c05a63d75bfd3c08da9",
                 "shasum": ""
             },
             "require": {
@@ -4419,7 +4419,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-01T08:55:04+00:00"
+            "time": "2025-12-01T10:32:29+00:00"
         },
         {
             "name": "ghostwriter/psalm-plugin",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#ecac8c6` to `dev-main#13ba985`.

This pull request changes the following file(s): 

- Update `composer.lock`