### PR TITLE
Update illuminate/contracts to version 12.42.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.41.1",
-        "illuminate/contracts": "^12.41.1",
+        "illuminate/contracts": "^12.42.0",
         "illuminate/database": "^12.41.1",
         "illuminate/events": "^12.41.1",
         "phpoffice/phpspreadsheet": "^5.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8b2f965740bdecf5a0f8753bbb004f0",
+    "content-hash": "ae9a8fbcd5a1dbb9e42f53953566b17d",
     "packages": [
         {
             "name": "brick/math",
@@ -1140,7 +1140,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.41.1",
+            "version": "v12.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.41.1` to `12.42.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`