### PR TITLE
Update illuminate/events to version 12.42.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.42.0",
         "illuminate/contracts": "^12.42.0",
         "illuminate/database": "^12.42.0",
-        "illuminate/events": "^12.41.1",
+        "illuminate/events": "^12.42.0",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "554841755c9cc7c9a33de5320266a3a6",
+    "content-hash": "ec0d7e7a2077f8c1c8b473cf64a61141",
     "packages": [
         {
             "name": "brick/math",
@@ -1259,7 +1259,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.41.1",
+            "version": "v12.42.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.41.1` to `12.42.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`