### PR TITLE
Update composer-unused phar to version 0.9.5

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -3,7 +3,7 @@
   <phar name="composer" version="^2.9.2" installed="2.9.2" location="./tools/phar/composer" copy="true"/>
   <phar name="composer-normalize" version="^2.48.2" installed="2.48.2" location="./tools/phar/composer-normalize" copy="true"/>
   <phar name="composer-require-checker" version="^4.19.0" installed="4.19.0" location="./tools/phar/composer-require-checker" copy="true"/>
-  <phar name="composer-unused" version="^0.9.4" installed="0.9.5" location="./tools/phar/composer-unused" copy="true"/>
+  <phar name="composer-unused" version="^0.9.5" installed="0.9.5" location="./tools/phar/composer-unused" copy="true"/>
   <phar name="infection" version="^0.31.1" installed="0.31.9" location="./tools/phar/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.1" installed="1.4.1" location="./tools/phar/phpbench" copy="true"/>


### PR DESCRIPTION
Updates composer-unused phar file to 0.9.5 version.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/composer-unused`