### PR TITLE
Update phpdocumentor phar 3.8.1 to 3.9.1

### DIFF
--- a/phive.xml
+++ b/phive.xml
@@ -7,7 +7,7 @@
   <phar name="infection" version="^0.31.9" installed="0.31.9" location="./tools/phar/infection" copy="true"/>
   <phar name="phar-io/phive" version="^0.16.0" installed="0.16.0" location="./tools/phar/phive" copy="true"/>
   <phar name="phpbench" version="^1.4.3" installed="1.4.3" location="./tools/phar/phpbench" copy="true"/>
-  <phar name="phpdocumentor" version="^3.8.1" installed="3.8.1" location="./tools/phar/phpdocumentor" copy="true"/>
+  <phar name="phpdocumentor" version="^3.9.1" installed="3.9.1" location="./tools/phar/phpdocumentor" copy="true"/>
   <phar name="phpunit" version="^12.3.1" installed="12.3.1" location="./tools/phar/phpunit" copy="true"/>
   <phar name="psalm" version="^6.14.1" installed="6.14.1" location="./tools/phar/psalm" copy="true"/>
 </phive>


### PR DESCRIPTION
Updates phpdocumentor phar file from 3.8.1 to 3.9.1.

This pull request changes the following file(s): 

- Update `phive.xml`
- Update `tools/phar/phpdocumentor`