### PR TITLE
Update illuminate/events to version 12.43.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.42.0",
         "illuminate/contracts": "^12.43.1",
         "illuminate/database": "^12.42.0",
-        "illuminate/events": "^12.42.0",
+        "illuminate/events": "^12.43.1",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3772c80dc789469b6e6c845fbee3d7e1",
+    "content-hash": "1e0dcd3786718783cf353dc7f7f259ef",
     "packages": [
         {
             "name": "brick/math",
@@ -1263,7 +1263,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.42.0",
+            "version": "v12.43.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.42.0` to `12.43.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`