### PR TITLE
Update illuminate/events to version 12.44.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.43.1",
         "illuminate/contracts": "^12.43.1",
         "illuminate/database": "^12.43.1",
-        "illuminate/events": "^12.43.1",
+        "illuminate/events": "^12.44.0",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65b5214588a5c0d6d5f4d9c44c6c85c6",
+    "content-hash": "f1190fcfdfe092aa611ee6d092348f8a",
     "packages": [
         {
             "name": "brick/math",
@@ -1263,7 +1263,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.43.1",
+            "version": "v12.44.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.43.1` to `12.44.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`