### PR TITLE
Update illuminate/events to version 12.45.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.44.0",
         "illuminate/contracts": "^12.45.0",
         "illuminate/database": "^12.44.0",
-        "illuminate/events": "^12.44.0",
+        "illuminate/events": "^12.45.0",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6fa5fadbdd14224bed4b1241d3db714d",
+    "content-hash": "87a67ca1b803072ef308971f971897c4",
     "packages": [
         {
             "name": "brick/math",
@@ -1265,7 +1265,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.44.0",
+            "version": "v12.45.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.44.0` to `12.45.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`