### PR TITLE
Update illuminate/events to version 12.45.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.45.0",
         "illuminate/contracts": "^12.45.0",
         "illuminate/database": "^12.45.0",
-        "illuminate/events": "^12.45.0",
+        "illuminate/events": "^12.45.1",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "79fb8f4be6aca045a14c6c737d0068ed",
+    "content-hash": "5602455a20ba114d887448064ee79fe1",
     "packages": [
         {
             "name": "brick/math",
@@ -1265,7 +1265,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.45.0",
+            "version": "v12.45.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.45.0` to `12.45.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`