### PR TITLE
Update illuminate/events to version 12.45.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.45.0",
         "illuminate/contracts": "^12.45.2",
         "illuminate/database": "^12.45.1",
-        "illuminate/events": "^12.45.1",
+        "illuminate/events": "^12.45.2",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9519bb7f51ffbeea40fdc78f51910904",
+    "content-hash": "5f7a9d0444245516a22ae8a3de5261fe",
     "packages": [
         {
             "name": "brick/math",
@@ -1265,7 +1265,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.45.1",
+            "version": "v12.45.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.45.1` to `12.45.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`