### PR TITLE
Update illuminate/database to version 12.45.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.45.2",
         "illuminate/contracts": "^12.45.2",
-        "illuminate/database": "^12.45.1",
+        "illuminate/database": "^12.45.2",
         "illuminate/events": "^12.45.2",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cff87784b984dbe8ff2b237207d789fa",
+    "content-hash": "06f0455d0251a598cdcf6764007b80ae",
     "packages": [
         {
             "name": "brick/math",
@@ -1193,7 +1193,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v12.45.1",
+            "version": "v12.45.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v12.45.1` to `12.45.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`