### PR TITLE
Update illuminate/events to version 12.46.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.45.2",
         "illuminate/contracts": "^12.45.2",
         "illuminate/database": "^12.45.2",
-        "illuminate/events": "^12.45.2",
+        "illuminate/events": "^12.46.0",
         "phpoffice/phpspreadsheet": "^5.3.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06f0455d0251a598cdcf6764007b80ae",
+    "content-hash": "82087d3321ffe211898046292ebbbf4a",
     "packages": [
         {
             "name": "brick/math",
@@ -1265,7 +1265,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.45.2",
+            "version": "v12.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.45.2` to `12.46.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`