### PR TITLE
Update illuminate/contracts to version 12.46.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.46.0",
-        "illuminate/contracts": "^12.45.2",
+        "illuminate/contracts": "^12.46.0",
         "illuminate/database": "^12.46.0",
         "illuminate/events": "^12.46.0",
         "phpoffice/phpspreadsheet": "^5.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7db697505d66734d43a59bfc13fe2447",
+    "content-hash": "a3369abc350af1bf0614f40549c2b2ae",
     "packages": [
         {
             "name": "brick/math",
@@ -1145,7 +1145,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.45.2",
+            "version": "v12.46.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.45.2` to `12.46.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`