### PR TITLE
Update illuminate/contracts to version 12.48.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.47.0",
-        "illuminate/contracts": "^12.47.0",
+        "illuminate/contracts": "^12.48.1",
         "illuminate/database": "^12.47.0",
         "illuminate/events": "^12.47.0",
         "phpoffice/phpspreadsheet": "^5.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ed8218519c707c96ef6f00fe26bb44de",
+    "content-hash": "9945ca621411e97ec14088ca10e1d6e3",
     "packages": [
         {
             "name": "brick/math",
@@ -1145,7 +1145,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.47.0",
+            "version": "v12.48.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.47.0` to `12.48.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`