### PR TITLE
Update illuminate/events to version 12.48.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.48.1",
         "illuminate/contracts": "^12.48.1",
         "illuminate/database": "^12.47.0",
-        "illuminate/events": "^12.47.0",
+        "illuminate/events": "^12.48.1",
         "phpoffice/phpspreadsheet": "^5.4.0",
         "symfony/css-selector": "^8.0.0",
         "symfony/dom-crawler": "^8.0.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd639da1af4ca47ce63ed4d3fc928116",
+    "content-hash": "f3e5f026be571e9ad4f9761880db8b55",
     "packages": [
         {
             "name": "brick/math",
@@ -1265,7 +1265,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.47.0",
+            "version": "v12.48.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.47.0` to `12.48.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`