### PR TITLE
Update illuminate/contracts to version 12.51.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.50.0",
-        "illuminate/contracts": "^12.50.0",
+        "illuminate/contracts": "^12.51.0",
         "illuminate/database": "^12.50.0",
         "illuminate/events": "^12.51.0",
         "phpoffice/phpspreadsheet": "^5.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bcd1aad72e8b491f8926c1b4d268cf7f",
+    "content-hash": "ce7d1e60661a320b5957c9a7468782bf",
     "packages": [
         {
             "name": "brick/math",
@@ -1146,7 +1146,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.50.0",
+            "version": "v12.51.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.50.0` to `12.51.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`