### PR TITLE
Update ghostwriter/console to version 0.1.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
         "ghostwriter/config": "^2.0.2",
-        "ghostwriter/console": "^0.1.2",
+        "ghostwriter/console": "^0.1.3",
         "ghostwriter/container": "^6.0.1",
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9606c67d03fa1ea84f1c1f3861fe88cf",
+    "content-hash": "19560414e59e2c50c9ff48dec8530c1d",
     "packages": [
         {
             "name": "brick/math",
@@ -380,31 +380,31 @@
         },
         {
             "name": "ghostwriter/console",
-            "version": "0.1.2",
+            "version": "0.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/console.git",
-                "reference": "9d3649ec7d444be5457d06b58de4c7cc097e02e0"
+                "reference": "b097c4e7bd69570d2dd255746d2ae834a6dcb054"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/console/zipball/9d3649ec7d444be5457d06b58de4c7cc097e02e0",
-                "reference": "9d3649ec7d444be5457d06b58de4c7cc097e02e0",
+                "url": "https://api.github.com/repos/ghostwriter/console/zipball/b097c4e7bd69570d2dd255746d2ae834a6dcb054",
+                "reference": "b097c4e7bd69570d2dd255746d2ae834a6dcb054",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "ghostwriter/config": "^2.0.1",
+                "ghostwriter/config": "^2.0.2",
                 "ghostwriter/container": "^6.0.1",
                 "php": "~8.4.0 || ~8.5.0",
-                "symfony/console": "^7.3.6 || ^8.0.0"
+                "symfony/console": "^8.0.4"
             },
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^12.4.4",
-                "symfony/var-dumper": "^7.4.0"
+                "phpunit/phpunit": "^13.0.2",
+                "symfony/var-dumper": "^8.0.4"
             },
             "type": "library",
             "extra": {
@@ -425,7 +425,7 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "BSD-4-Clause"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
@@ -453,7 +453,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-27T13:58:10+00:00"
+            "time": "2026-02-14T18:44:07+00:00"
         },
         {
             "name": "ghostwriter/container",
@@ -5759,9 +5759,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ghostwriter/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the `ghostwriter/console` dependency from `0.1.2` to `0.1.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`