### PR TITLE
Update illuminate/contracts to version 12.53.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.52.0",
-        "illuminate/contracts": "^12.52.0",
+        "illuminate/contracts": "^12.53.0",
         "illuminate/database": "^12.52.0",
         "illuminate/events": "^12.53.0",
         "phpoffice/phpspreadsheet": "^5.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "769d85c05e7f8f32f5aacc4f31bc307b",
+    "content-hash": "3877f1969244e2e19e47cd1e2a67cff6",
     "packages": [
         {
             "name": "brick/math",
@@ -1146,16 +1146,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.52.0",
+            "version": "v12.53.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "620d82bad07f55fcb7f5125f44c9d9b93335fb8c"
+                "reference": "099fd9b56ccaf776facaa27699b960a3f2451127"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/620d82bad07f55fcb7f5125f44c9d9b93335fb8c",
-                "reference": "620d82bad07f55fcb7f5125f44c9d9b93335fb8c",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/099fd9b56ccaf776facaa27699b960a3f2451127",
+                "reference": "099fd9b56ccaf776facaa27699b960a3f2451127",
                 "shasum": ""
             },
             "require": {
@@ -1190,7 +1190,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-10T18:16:44+00:00"
+            "time": "2026-02-20T14:37:40+00:00"
         },
         {
             "name": "illuminate/database",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.52.0` to `12.53.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`