### PR TITLE
Update phpoffice/phpspreadsheet to version 5.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "illuminate/contracts": "^12.53.0",
         "illuminate/database": "^12.53.0",
         "illuminate/events": "^12.53.0",
-        "phpoffice/phpspreadsheet": "^5.4.0",
+        "phpoffice/phpspreadsheet": "^5.5.0",
         "symfony/css-selector": "^8.0.6",
         "symfony/dom-crawler": "^8.0.6"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b0f6afe01ebc41c9f713bc1eff60081",
+    "content-hash": "aa3f7170cb8666608691734da03b8d0f",
     "packages": [
         {
             "name": "brick/math",
@@ -1901,16 +1901,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.4.0",
+            "version": "5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "48f2fe37d64c2dece0ef71fb2ac55497566782af"
+                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/48f2fe37d64c2dece0ef71fb2ac55497566782af",
-                "reference": "48f2fe37d64c2dece0ef71fb2ac55497566782af",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/eecd31b885a1c8192f12738130f85bbc6e8906ba",
+                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba",
                 "shasum": ""
             },
             "require": {
@@ -2004,9 +2004,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.4.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.5.0"
             },
-            "time": "2026-01-11T04:52:00+00:00"
+            "time": "2026-03-01T00:58:56+00:00"
         },
         {
             "name": "psr/clock",
@@ -5759,9 +5759,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ghostwriter/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the `phpoffice/phpspreadsheet` dependency from `5.4.0` to `5.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`