### PR TITLE
Update illuminate/contracts to version 12.54.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^12.54.1",
-        "illuminate/contracts": "^12.53.0",
+        "illuminate/contracts": "^12.54.1",
         "illuminate/database": "^12.53.0",
         "illuminate/events": "^12.53.0",
         "phpoffice/phpspreadsheet": "^5.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c18c4d590897b4dc04cb278705e463de",
+    "content-hash": "b04908137a53b6f5e1fef966c39f099d",
     "packages": [
         {
             "name": "brick/math",
@@ -1146,7 +1146,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v12.53.0",
+            "version": "v12.54.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v12.53.0` to `12.54.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`