### PR TITLE
Update illuminate/events to version 12.54.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^12.54.1",
         "illuminate/contracts": "^12.54.1",
         "illuminate/database": "^12.54.1",
-        "illuminate/events": "^12.53.0",
+        "illuminate/events": "^12.54.1",
         "phpoffice/phpspreadsheet": "^5.5.0",
         "symfony/css-selector": "^8.0.6",
         "symfony/dom-crawler": "^8.0.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "413583eada7df2f52756a969bbb81ef0",
+    "content-hash": "09df2c5f9fc3a0f75fcc24b73529ebad",
     "packages": [
         {
             "name": "brick/math",
@@ -1266,16 +1266,16 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v12.53.0",
+            "version": "v12.54.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
-                "reference": "b71e42451496175f8fd898cb6a67ad7fd613d00b"
+                "reference": "ff22aa6017bdbd90ace660f50638ed9c580ba555"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/events/zipball/b71e42451496175f8fd898cb6a67ad7fd613d00b",
-                "reference": "b71e42451496175f8fd898cb6a67ad7fd613d00b",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/ff22aa6017bdbd90ace660f50638ed9c580ba555",
+                "reference": "ff22aa6017bdbd90ace660f50638ed9c580ba555",
                 "shasum": ""
             },
             "require": {
@@ -1317,7 +1317,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-02-23T15:43:34+00:00"
+            "time": "2026-03-05T16:20:14+00:00"
         },
         {
             "name": "illuminate/macroable",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v12.53.0` to `12.54.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`