### PR TITLE
Update illuminate/events to version 13.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^13.0.0",
         "illuminate/contracts": "^13.1.0",
         "illuminate/database": "^13.0.0",
-        "illuminate/events": "^13.0.0",
+        "illuminate/events": "^13.1.0",
         "phpoffice/phpspreadsheet": "^5.5.0",
         "symfony/css-selector": "^8.0.6",
         "symfony/dom-crawler": "^8.0.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5eef71c7f94bdc6c9d46501a210cb51f",
+    "content-hash": "f156d0aea1e0de226de584449aa6d6f9",
     "packages": [
         {
             "name": "brick/math",
@@ -1263,7 +1263,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.0.0",
+            "version": "v13.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.0.0` to `13.1.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`