### PR TITLE
Update illuminate/events to version 13.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^13.2.0",
         "illuminate/contracts": "^13.2.0",
         "illuminate/database": "^13.2.0",
-        "illuminate/events": "^13.1.1",
+        "illuminate/events": "^13.2.0",
         "phpoffice/phpspreadsheet": "^5.5.0",
         "symfony/css-selector": "^8.0.6",
         "symfony/dom-crawler": "^8.0.6"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3468d1e57591a8aa53bfd8a388d7478f",
+    "content-hash": "54bf4e0dbc2398d7bcb85d5c63f83409",
     "packages": [
         {
             "name": "brick/math",
@@ -1263,7 +1263,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.1.1",
+            "version": "v13.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.1.1` to `13.2.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`