### PR TITLE
Update illuminate/contracts to version 13.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "ghostwriter/filesystem": "^0.1.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.3.0",
-        "illuminate/contracts": "^13.3.0",
+        "illuminate/contracts": "^13.4.0",
         "illuminate/database": "^13.3.0",
         "illuminate/events": "^13.3.0",
         "phpoffice/phpspreadsheet": "^5.5.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f693e5e8d00350068b3cd521b0344f41",
+    "content-hash": "e33d0f8cd1d2282ee16ef3e59b2612d8",
     "packages": [
         {
             "name": "brick/math",
@@ -1144,7 +1144,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.3.0",
+            "version": "v13.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
@@ -5729,9 +5729,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ghostwriter/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.3.0` to `13.4.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`