### PR TITLE
Update illuminate/events to version 13.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "illuminate/collections": "^13.4.0",
         "illuminate/contracts": "^13.4.0",
         "illuminate/database": "^13.4.0",
-        "illuminate/events": "^13.3.0",
+        "illuminate/events": "^13.4.0",
         "phpoffice/phpspreadsheet": "^5.5.0",
         "symfony/css-selector": "^8.0.8",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ad6a5a5fd6ab1e346d674a57aba59721",
+    "content-hash": "7a26e3cc0d3df091fc05970971c54e6f",
     "packages": [
         {
             "name": "brick/math",
@@ -1263,16 +1263,16 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.3.0",
+            "version": "v13.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
-                "reference": "805d4558062e6ba58489aa326700273d4ef92a40"
+                "reference": "c04390e0b0a5d5c91a4e44b55baef2af6e30670a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/events/zipball/805d4558062e6ba58489aa326700273d4ef92a40",
-                "reference": "805d4558062e6ba58489aa326700273d4ef92a40",
+                "url": "https://api.github.com/repos/illuminate/events/zipball/c04390e0b0a5d5c91a4e44b55baef2af6e30670a",
+                "reference": "c04390e0b0a5d5c91a4e44b55baef2af6e30670a",
                 "shasum": ""
             },
             "require": {
@@ -1314,7 +1314,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-30T22:02:57+00:00"
+            "time": "2026-04-02T16:58:55+00:00"
         },
         {
             "name": "illuminate/macroable",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.3.0` to `13.4.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`