### PR TITLE
Update phpoffice/phpspreadsheet to version 5.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "illuminate/contracts": "^13.4.0",
         "illuminate/database": "^13.4.0",
         "illuminate/events": "^13.4.0",
-        "phpoffice/phpspreadsheet": "^5.5.0",
+        "phpoffice/phpspreadsheet": "^5.6.0",
         "symfony/css-selector": "^8.0.8",
         "symfony/dom-crawler": "^8.0.8"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "efa1a04270d595fbcb2498b77b612b7a",
+    "content-hash": "1e61451fa32f3ab5f54b32297c707d09",
     "packages": [
         {
             "name": "brick/math",
@@ -1898,16 +1898,16 @@
         },
         {
             "name": "phpoffice/phpspreadsheet",
-            "version": "5.5.0",
+            "version": "5.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPOffice/PhpSpreadsheet.git",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba"
+                "reference": "9b90dee03deb0d28761479c4a3a06fba5f7e012e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/eecd31b885a1c8192f12738130f85bbc6e8906ba",
-                "reference": "eecd31b885a1c8192f12738130f85bbc6e8906ba",
+                "url": "https://api.github.com/repos/PHPOffice/PhpSpreadsheet/zipball/9b90dee03deb0d28761479c4a3a06fba5f7e012e",
+                "reference": "9b90dee03deb0d28761479c4a3a06fba5f7e012e",
                 "shasum": ""
             },
             "require": {
@@ -2001,9 +2001,9 @@
             ],
             "support": {
                 "issues": "https://github.com/PHPOffice/PhpSpreadsheet/issues",
-                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.5.0"
+                "source": "https://github.com/PHPOffice/PhpSpreadsheet/tree/5.6.0"
             },
-            "time": "2026-03-01T00:58:56+00:00"
+            "time": "2026-04-10T03:00:03+00:00"
         },
         {
             "name": "psr/clock",


### PR DESCRIPTION
Updates the `phpoffice/phpspreadsheet` dependency from `5.5.0` to `5.6.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`