### PR TITLE
Update illuminate/contracts to version 13.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.4.0",
-        "illuminate/contracts": "^13.4.0",
+        "illuminate/contracts": "^13.5.0",
         "illuminate/database": "^13.4.0",
         "illuminate/events": "^13.4.0",
         "phpoffice/phpspreadsheet": "^5.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f97ae69b61114e9b280c06422e19042",
+    "content-hash": "87b7bf94fa075fee1f273b068a0fd239",
     "packages": [
         {
             "name": "brick/math",
@@ -1161,16 +1161,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.4.0",
+            "version": "v13.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "8796cc5f30124b81210ae2f3b2ae0f69ad4fc7f8"
+                "reference": "022d9816b4ff052a3db5946a86be3cd2e224db0f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/8796cc5f30124b81210ae2f3b2ae0f69ad4fc7f8",
-                "reference": "8796cc5f30124b81210ae2f3b2ae0f69ad4fc7f8",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/022d9816b4ff052a3db5946a86be3cd2e224db0f",
+                "reference": "022d9816b4ff052a3db5946a86be3cd2e224db0f",
                 "shasum": ""
             },
             "require": {
@@ -1205,7 +1205,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-26T17:13:01+00:00"
+            "time": "2026-04-12T17:46:48+00:00"
         },
         {
             "name": "illuminate/database",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.4.0` to `13.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`