### PR TITLE
Update illuminate/events to version 13.5.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.5.0",
         "illuminate/contracts": "^13.5.0",
         "illuminate/database": "^13.4.0",
-        "illuminate/events": "^13.4.0",
+        "illuminate/events": "^13.5.0",
         "phpoffice/phpspreadsheet": "^5.6.0",
         "symfony/css-selector": "^8.0.8",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "783296fc9a26a145d4466b44b2dcba36",
+    "content-hash": "4f9be4c01215a8bc4bb44d09857f9d87",
     "packages": [
         {
             "name": "brick/math",
@@ -1280,7 +1280,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.4.0",
+            "version": "v13.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.4.0` to `13.5.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`