### PR TITLE
Update illuminate/events to version 13.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.6.0",
         "illuminate/contracts": "^13.5.0",
         "illuminate/database": "^13.5.0",
-        "illuminate/events": "^13.5.0",
+        "illuminate/events": "^13.6.0",
         "phpoffice/phpspreadsheet": "^5.6.0",
         "symfony/css-selector": "^8.0.8",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8d3bdf60a96dac2d4ecd59b35155353",
+    "content-hash": "2e6013e9e224c34cb475f354b853ae37",
     "packages": [
         {
             "name": "brick/math",
@@ -1280,7 +1280,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.5.0",
+            "version": "v13.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.5.0` to `13.6.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`