### PR TITLE
Update illuminate/contracts to version 13.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.6.0",
-        "illuminate/contracts": "^13.5.0",
+        "illuminate/contracts": "^13.6.0",
         "illuminate/database": "^13.5.0",
         "illuminate/events": "^13.6.0",
         "phpoffice/phpspreadsheet": "^5.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8e9ec69a38d6216fe50f55d6e038a554",
+    "content-hash": "3771c32e187cf8bc1503251f28d6556e",
     "packages": [
         {
             "name": "brick/math",
@@ -1161,7 +1161,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.5.0",
+            "version": "v13.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.5.0` to `13.6.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`