### PR TITLE
Update illuminate/events to version 13.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.7.0",
         "illuminate/contracts": "^13.7.0",
         "illuminate/database": "^13.7.0",
-        "illuminate/events": "^13.7.0",
+        "illuminate/events": "^13.8.0",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2722fa47fb1830510d981a3d0ef29e00",
+    "content-hash": "edd1428f5b7baa771ecc24ba2455ceef",
     "packages": [
         {
             "name": "brick/math",
@@ -1280,7 +1280,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.7.0",
+            "version": "v13.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.7.0` to `13.8.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`