### PR TITLE
Update illuminate/contracts to version 13.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.7.0",
-        "illuminate/contracts": "^13.7.0",
+        "illuminate/contracts": "^13.8.0",
         "illuminate/database": "^13.7.0",
         "illuminate/events": "^13.8.0",
         "phpoffice/phpspreadsheet": "^5.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edd1428f5b7baa771ecc24ba2455ceef",
+    "content-hash": "15448b8ef421b4befa0676369d97e48c",
     "packages": [
         {
             "name": "brick/math",
@@ -1161,16 +1161,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.7.0",
+            "version": "v13.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "a5f08426a807faac42616f733113ba263779f2dd"
+                "reference": "ce6f5561f88743639c76835ad82cfe39b468bdc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/a5f08426a807faac42616f733113ba263779f2dd",
-                "reference": "a5f08426a807faac42616f733113ba263779f2dd",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/ce6f5561f88743639c76835ad82cfe39b468bdc8",
+                "reference": "ce6f5561f88743639c76835ad82cfe39b468bdc8",
                 "shasum": ""
             },
             "require": {
@@ -1205,7 +1205,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-24T14:55:56+00:00"
+            "time": "2026-04-28T17:16:27+00:00"
         },
         {
             "name": "illuminate/database",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.7.0` to `13.8.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`