### PR TITLE
Update illuminate/database to version 13.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.7.0",
         "illuminate/contracts": "^13.8.0",
-        "illuminate/database": "^13.7.0",
+        "illuminate/database": "^13.8.0",
         "illuminate/events": "^13.8.0",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "15448b8ef421b4befa0676369d97e48c",
+    "content-hash": "eb9972acb82ef17084be1aa0258d6a4c",
     "packages": [
         {
             "name": "brick/math",
@@ -1209,16 +1209,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v13.7.0",
+            "version": "v13.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "29efb21135ec7c28a71c61c9c4350e36601f206e"
+                "reference": "b04b338f22d4625e78d1427d3eb68758c17a97eb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/29efb21135ec7c28a71c61c9c4350e36601f206e",
-                "reference": "29efb21135ec7c28a71c61c9c4350e36601f206e",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/b04b338f22d4625e78d1427d3eb68758c17a97eb",
+                "reference": "b04b338f22d4625e78d1427d3eb68758c17a97eb",
                 "shasum": ""
             },
             "require": {
@@ -1231,7 +1231,8 @@
                 "illuminate/support": "^13.0",
                 "laravel/serializable-closure": "^2.0.10",
                 "php": "^8.3",
-                "symfony/polyfill-php85": "^1.33"
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34"
             },
             "suggest": {
                 "ext-filter": "Required to use the Postgres database driver.",
@@ -1276,7 +1277,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-04-27T15:25:58+00:00"
+            "time": "2026-05-04T12:35:50+00:00"
         },
         {
             "name": "illuminate/events",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v13.7.0` to `13.8.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`