### PR TITLE
Update illuminate/events to version 13.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.8.0",
         "illuminate/contracts": "^13.8.0",
         "illuminate/database": "^13.8.0",
-        "illuminate/events": "^13.8.0",
+        "illuminate/events": "^13.9.0",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "80f0915ede61a37b8c46555929b873d2",
+    "content-hash": "f5bc28f1da16a88db8f723e89d403eb4",
     "packages": [
         {
             "name": "brick/math",
@@ -1282,7 +1282,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.8.0",
+            "version": "v13.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.8.0` to `13.9.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`