### PR TITLE
Update illuminate/database to version 13.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "guzzlehttp/guzzle": "^7.10.0",
         "illuminate/collections": "^13.9.0",
         "illuminate/contracts": "^13.9.0",
-        "illuminate/database": "^13.8.0",
+        "illuminate/database": "^13.9.0",
         "illuminate/events": "^13.9.0",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7996b67c55f3dda81f7b1d127ce2a287",
+    "content-hash": "43135277f302f6cc35792705b9348e0d",
     "packages": [
         {
             "name": "brick/math",
@@ -1210,16 +1210,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v13.8.0",
+            "version": "v13.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "b04b338f22d4625e78d1427d3eb68758c17a97eb"
+                "reference": "c0f1b78ed5e4cbdad0744181050aa689c477124f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/b04b338f22d4625e78d1427d3eb68758c17a97eb",
-                "reference": "b04b338f22d4625e78d1427d3eb68758c17a97eb",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/c0f1b78ed5e4cbdad0744181050aa689c477124f",
+                "reference": "c0f1b78ed5e4cbdad0744181050aa689c477124f",
                 "shasum": ""
             },
             "require": {
@@ -1232,8 +1232,9 @@
                 "illuminate/support": "^13.0",
                 "laravel/serializable-closure": "^2.0.10",
                 "php": "^8.3",
-                "symfony/polyfill-php84": "^1.34",
-                "symfony/polyfill-php85": "^1.34"
+                "symfony/polyfill-php84": "^1.36",
+                "symfony/polyfill-php85": "^1.36",
+                "symfony/polyfill-php86": "^1.36"
             },
             "suggest": {
                 "ext-filter": "Required to use the Postgres database driver.",
@@ -1278,7 +1279,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-04T12:35:50+00:00"
+            "time": "2026-05-10T15:49:54+00:00"
         },
         {
             "name": "illuminate/events",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v13.8.0` to `13.9.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`