### PR TITLE
Update illuminate/events to version 13.11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.9.0",
         "illuminate/contracts": "^13.9.0",
         "illuminate/database": "^13.9.0",
-        "illuminate/events": "^13.9.0",
+        "illuminate/events": "^13.11.0",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "df1a12e540d21d63139d210a27b7518c",
+    "content-hash": "2ef10b2b98d85537f6ba99d7e956e692",
     "packages": [
         {
             "name": "brick/math",
@@ -1284,7 +1284,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.9.0",
+            "version": "v13.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.9.0` to `13.11.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`