### PR TITLE
Update illuminate/contracts to version 13.11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.1",
         "illuminate/collections": "^13.11.0",
-        "illuminate/contracts": "^13.9.0",
+        "illuminate/contracts": "^13.11.0",
         "illuminate/database": "^13.9.0",
         "illuminate/events": "^13.11.0",
         "phpoffice/phpspreadsheet": "^5.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b152dd2060ae2cda77d6a2dc87ebbc5a",
+    "content-hash": "a9f5eaaa7182738c6435633b1fb3f2fe",
     "packages": [
         {
             "name": "brick/math",
@@ -1163,16 +1163,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.9.0",
+            "version": "v13.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "71dba8668753f7c6ea862bc4258eba6513b592ec"
+                "reference": "b88c1134feb4253a71048e7e2b5c431e9b3ab95b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/71dba8668753f7c6ea862bc4258eba6513b592ec",
-                "reference": "71dba8668753f7c6ea862bc4258eba6513b592ec",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/b88c1134feb4253a71048e7e2b5c431e9b3ab95b",
+                "reference": "b88c1134feb4253a71048e7e2b5c431e9b3ab95b",
                 "shasum": ""
             },
             "require": {
@@ -1207,7 +1207,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-06T18:50:26+00:00"
+            "time": "2026-05-13T13:44:10+00:00"
         },
         {
             "name": "illuminate/database",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.9.0` to `13.11.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`