### PR TITLE
Update illuminate/events to version 13.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.11.0",
         "illuminate/contracts": "^13.11.0",
         "illuminate/database": "^13.11.0",
-        "illuminate/events": "^13.11.0",
+        "illuminate/events": "^13.11.1",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",
         "symfony/dom-crawler": "^8.0.8"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52bdf3caa1f42709d626882e2690a1cc",
+    "content-hash": "36bab46c0884119a2cdaf7353f883142",
     "packages": [
         {
             "name": "brick/math",
@@ -1284,7 +1284,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.11.0",
+            "version": "v13.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.11.0` to `13.11.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`