### PR TITLE
Update illuminate/contracts to version 13.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.1",
         "illuminate/collections": "^13.11.0",
-        "illuminate/contracts": "^13.11.0",
+        "illuminate/contracts": "^13.11.1",
         "illuminate/database": "^13.11.0",
         "illuminate/events": "^13.11.1",
         "phpoffice/phpspreadsheet": "^5.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "36bab46c0884119a2cdaf7353f883142",
+    "content-hash": "0458c2a7fa70b77960b4ffacf43f3f2a",
     "packages": [
         {
             "name": "brick/math",
@@ -1163,7 +1163,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.11.0",
+            "version": "v13.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.11.0` to `13.11.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`