### PR TITLE
Update illuminate/database to version 13.11.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "guzzlehttp/guzzle": "^7.10.1",
         "illuminate/collections": "^13.11.0",
         "illuminate/contracts": "^13.11.1",
-        "illuminate/database": "^13.11.0",
+        "illuminate/database": "^13.11.1",
         "illuminate/events": "^13.11.1",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0458c2a7fa70b77960b4ffacf43f3f2a",
+    "content-hash": "3e35c2443560addaff5dcb94fcd7830c",
     "packages": [
         {
             "name": "brick/math",
@@ -1211,7 +1211,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v13.11.0",
+            "version": "v13.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the `illuminate/database` dependency from `v13.11.0` to `13.11.1`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`