### PR TITLE
Update illuminate/events to version 13.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "illuminate/collections": "^13.11.1",
         "illuminate/contracts": "^13.11.1",
         "illuminate/database": "^13.11.1",
-        "illuminate/events": "^13.11.1",
+        "illuminate/events": "^13.11.2",
         "phpoffice/phpspreadsheet": "^5.7.0",
         "symfony/css-selector": "^8.0.9",
         "symfony/dom-crawler": "^8.0.12"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3115bc1e7644d79630593721d19f826e",
+    "content-hash": "c45ea2d65717319e058a6b7a0e7d07b4",
     "packages": [
         {
             "name": "brick/math",
@@ -1284,7 +1284,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.11.1",
+            "version": "v13.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.11.1` to `13.11.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`