### PR TITLE
Update illuminate/contracts to version 13.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.1",
         "illuminate/collections": "^13.11.1",
-        "illuminate/contracts": "^13.11.1",
+        "illuminate/contracts": "^13.11.2",
         "illuminate/database": "^13.11.1",
         "illuminate/events": "^13.11.2",
         "phpoffice/phpspreadsheet": "^5.7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c45ea2d65717319e058a6b7a0e7d07b4",
+    "content-hash": "7a0e463a55e1f59e3383dae5f7c201c8",
     "packages": [
         {
             "name": "brick/math",
@@ -1163,7 +1163,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.11.1",
+            "version": "v13.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.11.1` to `13.11.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`