### PR TITLE
Update illuminate/collections to version 13.11.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
         "ghostwriter/container": "^7.0.1",
         "ghostwriter/filesystem": "^0.2.0",
         "guzzlehttp/guzzle": "^7.10.1",
-        "illuminate/collections": "^13.11.1",
+        "illuminate/collections": "^13.11.2",
         "illuminate/contracts": "^13.11.2",
         "illuminate/database": "^13.11.2",
         "illuminate/events": "^13.11.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "245d2160bdf9fe87e09d1793f75da713",
+    "content-hash": "4cc5859c8748e1bcb5916a46014471b3",
     "packages": [
         {
             "name": "brick/math",
@@ -995,7 +995,7 @@
         },
         {
             "name": "illuminate/collections",
-            "version": "v13.11.1",
+            "version": "v13.11.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",


### PR DESCRIPTION
Updates the `illuminate/collections` dependency from `v13.11.1` to `13.11.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`