### PR TITLE
Update illuminate/conditionable to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1273,7 +1273,7 @@
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",


### PR DESCRIPTION
Updates the `illuminate/conditionable` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`