### PR TITLE
Update illuminate/pipeline to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1603,7 +1603,7 @@
         },
         {
             "name": "illuminate/pipeline",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/pipeline.git",


### PR DESCRIPTION
Updates the `illuminate/pipeline` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`