### PR TITLE
Update illuminate/reflection to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1655,7 +1655,7 @@
         },
         {
             "name": "illuminate/reflection",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/reflection.git",


### PR DESCRIPTION
Updates the `illuminate/reflection` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`