### PR TITLE
Update illuminate/events to version 13.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "illuminate/collections": "^13.11.2",
         "illuminate/contracts": "^13.11.2",
         "illuminate/database": "^13.11.2",
-        "illuminate/events": "^13.11.2",
+        "illuminate/events": "^13.12.0",
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-escaper": "^2.18.0",
         "laminas/laminas-httphandlerrunner": "^2.13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c916ce4788d93c4bd09dea9d723e9d98",
+    "content-hash": "295d3c87b705f9eb7d610c20ca33c080",
     "packages": [
         {
             "name": "brick/math",
@@ -1502,7 +1502,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",
@@ -5309,16 +5309,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "1cc11f6b5bbc3d4e9e7c01f5bee0648de0d40643"
+                "reference": "33f2332341fecf8f3aaa266cd5862354a94d2c3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/1cc11f6b5bbc3d4e9e7c01f5bee0648de0d40643",
-                "reference": "1cc11f6b5bbc3d4e9e7c01f5bee0648de0d40643",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/33f2332341fecf8f3aaa266cd5862354a94d2c3a",
+                "reference": "33f2332341fecf8f3aaa266cd5862354a94d2c3a",
                 "shasum": ""
             },
             "require": {
-                "boundwize/structarmed": "^0.7.11",
+                "boundwize/structarmed": "^0.7.12",
                 "ext-apcu": "*",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
@@ -5429,7 +5429,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-26T13:51:07+00:00"
+            "time": "2026-05-26T18:12:02+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `illuminate/events` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`