### PR TITLE
Update ghostwriter/container to version 7.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "ext-pdo": "*",
         "ghostwriter/config": "^2.1.3",
         "ghostwriter/console": "^0.2.3",
-        "ghostwriter/container": "^7.0.1",
+        "ghostwriter/container": "^7.0.2",
         "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/http": "^0.2.0",
         "ghostwriter/json": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "295d3c87b705f9eb7d610c20ca33c080",
+    "content-hash": "a9e54c1617f442ff714a36b19a3750ae",
     "packages": [
         {
             "name": "brick/math",
@@ -516,16 +516,16 @@
         },
         {
             "name": "ghostwriter/container",
-            "version": "7.0.1",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/container.git",
-                "reference": "8e49e51d5558cb6482eac4da7170d75a765ee418"
+                "reference": "a5474864d2a54074fef019646bf7ca060eb3638b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/container/zipball/8e49e51d5558cb6482eac4da7170d75a765ee418",
-                "reference": "8e49e51d5558cb6482eac4da7170d75a765ee418",
+                "url": "https://api.github.com/repos/ghostwriter/container/zipball/a5474864d2a54074fef019646bf7ca060eb3638b",
+                "reference": "a5474864d2a54074fef019646bf7ca060eb3638b",
                 "shasum": ""
             },
             "require": {
@@ -536,10 +536,12 @@
                 "psr/container-implementation": "*"
             },
             "require-dev": {
+                "boundwize/structarmed": "^0.7.12",
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
+                "ghostwriter/testify": "^0.1.1",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.7",
+                "phpunit/phpunit": "^13.1.12",
                 "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
@@ -591,7 +593,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-22T17:22:16+00:00"
+            "time": "2026-05-27T01:57:36+00:00"
         },
         {
             "name": "ghostwriter/filesystem",


### PR DESCRIPTION
Updates the `ghostwriter/container` dependency from `7.0.1` to `7.0.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`