### PR TITLE
Update illuminate/bus to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1162,7 +1162,7 @@
         },
         {
             "name": "illuminate/bus",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/bus.git",


### PR DESCRIPTION
Updates the `illuminate/bus` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`