### PR TITLE
Update illuminate/macroable to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1559,7 +1559,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",


### PR DESCRIPTION
Updates the `illuminate/macroable` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`