### PR TITLE
Update illuminate/contracts to version 13.12.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "ghostwriter/json": "^3.0.2",
         "guzzlehttp/guzzle": "^7.10.4",
         "illuminate/collections": "^13.11.2",
-        "illuminate/contracts": "^13.11.2",
+        "illuminate/contracts": "^13.12.0",
         "illuminate/database": "^13.11.2",
         "illuminate/events": "^13.12.0",
         "laminas/laminas-diactoros": "^3.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a9e54c1617f442ff714a36b19a3750ae",
+    "content-hash": "a49d4de9f1b47fb764c5c081b0b60b88",
     "packages": [
         {
             "name": "brick/math",
@@ -1383,16 +1383,16 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "b88c1134feb4253a71048e7e2b5c431e9b3ab95b"
+                "reference": "dc805389d17f13821726423bf4fc90d3162bf90d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/b88c1134feb4253a71048e7e2b5c431e9b3ab95b",
-                "reference": "b88c1134feb4253a71048e7e2b5c431e9b3ab95b",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/dc805389d17f13821726423bf4fc90d3162bf90d",
+                "reference": "dc805389d17f13821726423bf4fc90d3162bf90d",
                 "shasum": ""
             },
             "require": {
@@ -1427,7 +1427,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-13T13:44:10+00:00"
+            "time": "2026-05-21T13:18:48+00:00"
         },
         {
             "name": "illuminate/database",


### PR DESCRIPTION
Updates the `illuminate/contracts` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`