### PR TITLE
Update illuminate/container to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1321,7 +1321,7 @@
         },
         {
             "name": "illuminate/container",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/container.git",


### PR DESCRIPTION
Updates the `illuminate/container` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`