### PR TITLE
Update illuminate/support to version 13.12.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1708,16 +1708,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v13.11.2",
+            "version": "v13.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "8aaaa17028851d410cd2f1489cecc921663e58d5"
+                "reference": "6f6d7e1743490638c2e0d62bdbae4cf05fbf577a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/8aaaa17028851d410cd2f1489cecc921663e58d5",
-                "reference": "8aaaa17028851d410cd2f1489cecc921663e58d5",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/6f6d7e1743490638c2e0d62bdbae4cf05fbf577a",
+                "reference": "6f6d7e1743490638c2e0d62bdbae4cf05fbf577a",
                 "shasum": ""
             },
             "require": {
@@ -1783,7 +1783,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-19T16:59:44+00:00"
+            "time": "2026-05-25T23:04:25+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",


### PR DESCRIPTION
Updates the `illuminate/support` dependency from `v13.11.2` to `13.12.0`.

This pull request changes the following file(s): 

- Update `composer.lock`