### PR TITLE
Update `guzzlehttp/guzzle` to version `7.10.6`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "ghostwriter/filesystem": "^0.2.0",
         "ghostwriter/http": "^0.2.0",
         "ghostwriter/json": "^3.0.2",
-        "guzzlehttp/guzzle": "^7.10.5",
+        "guzzlehttp/guzzle": "^7.10.6",
         "illuminate/collections": "^13.12.0",
         "illuminate/contracts": "^13.12.0",
         "illuminate/database": "^13.12.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c15eab545666d15248deeb9359d96e5e",
+    "content-hash": "241397543e5817b225e1a089031c7158",
     "packages": [
         {
             "name": "brick/math",
@@ -835,16 +835,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.5",
+            "version": "7.10.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148"
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7c8d84b39e680315f687e8662a9d6fb0865c5148",
-                "reference": "7c8d84b39e680315f687e8662a9d6fb0865c5148",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/e7412b3180912c01650cc66647f18c1d1cbe9b94",
+                "reference": "e7412b3180912c01650cc66647f18c1d1cbe9b94",
                 "shasum": ""
             },
             "require": {
@@ -942,7 +942,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.5"
+                "source": "https://github.com/guzzle/guzzle/tree/7.10.6"
             },
             "funding": [
                 {
@@ -958,7 +958,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T11:53:46+00:00"
+            "time": "2026-06-01T13:06:22+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
Updates the [`guzzlehttp/guzzle`](https://packagist.org/packages/guzzlehttp/guzzle) dependency from `7.10.5` to `7.10.6`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`