### PR TITLE
Update `illuminate/events` to version `13.13.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "illuminate/collections": "^13.12.0",
         "illuminate/contracts": "^13.12.0",
         "illuminate/database": "^13.12.0",
-        "illuminate/events": "^13.12.0",
+        "illuminate/events": "^13.13.0",
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-escaper": "^2.18.0",
         "laminas/laminas-httphandlerrunner": "^2.13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "241397543e5817b225e1a089031c7158",
+    "content-hash": "e4f5de014f707882c64cd086ee8baf9c",
     "packages": [
         {
             "name": "brick/math",
@@ -1504,7 +1504,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.12.0",
+            "version": "v13.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the [`illuminate/events`](https://packagist.org/packages/illuminate/events) dependency from `v13.12.0` to `13.13.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`