### PR TITLE
Update `illuminate/macroable` to version `13.13.0`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1559,7 +1559,7 @@
         },
         {
             "name": "illuminate/macroable",
-            "version": "v13.12.0",
+            "version": "v13.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",


### PR DESCRIPTION
Updates the [`illuminate/macroable`](https://packagist.org/packages/illuminate/macroable) dependency from `v13.12.0` to `13.13.0`.

This pull request changes the following file(s): 

- Update `composer.lock`