### PR TITLE
Update `illuminate/contracts` to version `13.13.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         "ghostwriter/json": "^3.0.2",
         "guzzlehttp/guzzle": "^7.10.6",
         "illuminate/collections": "^13.13.0",
-        "illuminate/contracts": "^13.12.0",
+        "illuminate/contracts": "^13.13.0",
         "illuminate/database": "^13.12.0",
         "illuminate/events": "^13.13.0",
         "laminas/laminas-diactoros": "^3.8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbd483a3e1877c471dc0a92792da3a59",
+    "content-hash": "2224dc82b496e31aa19ddb1884ef0571",
     "packages": [
         {
             "name": "brick/math",
@@ -1384,7 +1384,7 @@
         },
         {
             "name": "illuminate/contracts",
-            "version": "v13.12.0",
+            "version": "v13.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",


### PR DESCRIPTION
Updates the [`illuminate/contracts`](https://packagist.org/packages/illuminate/contracts) dependency from `v13.12.0` to `13.13.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`