### PR TITLE
Update `illuminate/database` to version `13.13.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "guzzlehttp/guzzle": "^7.10.6",
         "illuminate/collections": "^13.13.0",
         "illuminate/contracts": "^13.13.0",
-        "illuminate/database": "^13.12.0",
+        "illuminate/database": "^13.13.0",
         "illuminate/events": "^13.13.0",
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-escaper": "^2.18.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2224dc82b496e31aa19ddb1884ef0571",
+    "content-hash": "a5596925eedbdae5b8d07d825410b4e0",
     "packages": [
         {
             "name": "brick/math",
@@ -1432,16 +1432,16 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v13.12.0",
+            "version": "v13.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",
-                "reference": "b906694200284bea640c6014534473426ec83dd8"
+                "reference": "20f6309e6dcf0b38c062d3f62e15f36582943017"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/database/zipball/b906694200284bea640c6014534473426ec83dd8",
-                "reference": "b906694200284bea640c6014534473426ec83dd8",
+                "url": "https://api.github.com/repos/illuminate/database/zipball/20f6309e6dcf0b38c062d3f62e15f36582943017",
+                "reference": "20f6309e6dcf0b38c062d3f62e15f36582943017",
                 "shasum": ""
             },
             "require": {
@@ -1501,7 +1501,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-25T23:05:07+00:00"
+            "time": "2026-05-31T23:24:23+00:00"
         },
         {
             "name": "illuminate/events",


### PR DESCRIPTION
Updates the [`illuminate/database`](https://packagist.org/packages/illuminate/database) dependency from `v13.12.0` to `13.13.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`