### PR TITLE
Update `illuminate/events` to version `13.14.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "illuminate/collections": "^13.13.0",
         "illuminate/contracts": "^13.13.0",
         "illuminate/database": "^13.13.0",
-        "illuminate/events": "^13.13.0",
+        "illuminate/events": "^13.14.0",
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-escaper": "^2.18.0",
         "laminas/laminas-httphandlerrunner": "^2.13.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "08b9046321a96dc351268f37030cd675",
+    "content-hash": "164f061ee10e64888c1f007d2f31016c",
     "packages": [
         {
             "name": "brick/math",
@@ -1508,7 +1508,7 @@
         },
         {
             "name": "illuminate/events",
-            "version": "v13.13.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/events.git",


### PR DESCRIPTION
Updates the [`illuminate/events`](https://packagist.org/packages/illuminate/events) dependency from `v13.13.0` to `13.14.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`