### PR TITLE
Update `illuminate/support` to version `13.14.0`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1712,16 +1712,16 @@
         },
         {
             "name": "illuminate/support",
-            "version": "v13.13.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/support.git",
-                "reference": "6354b6d6888397752d3fe205404d10edc4299e01"
+                "reference": "f6a7548501831fbdd28e0e0883e72343a6d16e7e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/support/zipball/6354b6d6888397752d3fe205404d10edc4299e01",
-                "reference": "6354b6d6888397752d3fe205404d10edc4299e01",
+                "url": "https://api.github.com/repos/illuminate/support/zipball/f6a7548501831fbdd28e0e0883e72343a6d16e7e",
+                "reference": "f6a7548501831fbdd28e0e0883e72343a6d16e7e",
                 "shasum": ""
             },
             "require": {
@@ -1787,7 +1787,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-05-31T22:09:29+00:00"
+            "time": "2026-06-03T14:31:28+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",


### PR DESCRIPTION
Updates the [`illuminate/support`](https://packagist.org/packages/illuminate/support) dependency from `v13.13.0` to `13.14.0`.

This pull request changes the following file(s): 

- Update `composer.lock`