### PR TITLE
Update `illuminate/database` to version `13.14.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "guzzlehttp/guzzle": "^7.11.0",
         "illuminate/collections": "^13.14.0",
         "illuminate/contracts": "^13.14.0",
-        "illuminate/database": "^13.13.0",
+        "illuminate/database": "^13.14.0",
         "illuminate/events": "^13.14.0",
         "laminas/laminas-diactoros": "^3.8.0",
         "laminas/laminas-escaper": "^2.18.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d07f483dfdf8f16735eeafacf9212162",
+    "content-hash": "6686955c389624a1c1904f5685313ab3",
     "packages": [
         {
             "name": "brick/math",
@@ -1435,7 +1435,7 @@
         },
         {
             "name": "illuminate/database",
-            "version": "v13.13.0",
+            "version": "v13.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/database.git",


### PR DESCRIPTION
Updates the [`illuminate/database`](https://packagist.org/packages/illuminate/database) dependency from `v13.13.0` to `13.14.0`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`